### PR TITLE
Fix a misnamed exclusion rule

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
                 ],
                 path: ".",
                 exclude: [
-                    "Example",
+                    "ExampleApp",
                     "Tests",
                     "Source/Info.plist",
                     "Source/RxBluetoothKit.h"


### PR DESCRIPTION
There was a warning due to a misnamed package exclusion rule.